### PR TITLE
Some changes to allow scoped overrides and direct use of template functions

### DIFF
--- a/specs/index.html
+++ b/specs/index.html
@@ -2,16 +2,16 @@
   "http://www.w3.org/TR/html4/loose.dtd">
 <html>
   <head>
-    <title>Jasmine Test Runner</title>  
-    <link href="../../jasmine/lib/jasmine.css" rel="stylesheet"/>
-    <script src="../../jasmine/lib/jasmine.js"></script>
-    <script src="../../jasmine/lib/jasmine-html.js"></script>
+    <title>Jasmine Test Runner</title>
+    <link href="../../jasmine/lib/jasmine-core/jasmine.css" rel="stylesheet"/>
+    <script src="../../jasmine/lib/jasmine-core/jasmine.js"></script>
+    <script src="../../jasmine/lib/jasmine-core/jasmine-html.js"></script>
 
     <!--SOURCE-->
     <script src="../src/Jaml.js"></script>
     <script src="../src/Node.js"></script>
     <script src="../src/Template.js"></script>
-    
+
     <script>
       function require() {
         //do nothing for now.  this makes the web-based test run work
@@ -19,7 +19,7 @@
         //https://github.com/codespeaks/modulr
       }
     </script
-  
+
     <!--TEST-->
     <script src="node_spec.js"></script>
     <script src="template_spec.js"></script>

--- a/specs/jaml_spec.js
+++ b/specs/jaml_spec.js
@@ -5,7 +5,7 @@ describe("Jaml (top-level)", function() {
   beforeEach(function(){
     Jaml.templates = {};
   })
-  
+
   describe("you can register a template and then use it to render", function() {
     it("works with no data passed in (very simple)", function(){
       Jaml.register("color", function(){
@@ -14,11 +14,11 @@ describe("Jaml (top-level)", function() {
           li("green")
         )
       });
-    
+
       expect(Jaml.render("color")).
      toEqual("<ul>\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n");
     });
 
@@ -29,11 +29,11 @@ describe("Jaml (top-level)", function() {
           li(widget.secondaryColor)
         )
       });
-    
+
       expect(Jaml.render("color", {primaryColor:"red", secondaryColor:"green"} )).
      toEqual("<ul>\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n");
     });
 
@@ -44,32 +44,32 @@ describe("Jaml (top-level)", function() {
           li(widget.secondaryColor)
         )
       });
-    
+
       Jaml.register("shape", function(widget){
         p(widget.shape)
       });
-      
+
       var christmasTree = {primaryColor:"red", secondaryColor:"green", shape:"round"};
-      
+
       expect(Jaml.render("color", christmasTree )).
      toEqual("<ul>\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n");
-      
+
       expect(Jaml.render("shape", christmasTree )).
-     toEqual("<p>round</p>\n");        
+     toEqual("<p>round</p>\n");
     });
-    
+
     it("can override a template by using the same name", function(){
       var christmasTree = {shape:"round"};
-      
+
       Jaml.register("shape", function(widget){
         p(widget.shape)
       });
       expect(Jaml.render("shape", christmasTree )).
      toEqual("<p>round</p>\n");
-                   
+
       Jaml.register("shape", function(widget){
         div(widget.shape)
       });
@@ -77,7 +77,29 @@ describe("Jaml (top-level)", function() {
      toEqual("<div>round</div>\n");
 
     });
-    
-  });    
+
+
+
+    it("can use a template without registering it", function() {
+    	var christmasTree = {shape:"round"};
+    	expect(Jaml.render(function(widget){
+        p(widget.shape)
+      }, christmasTree )).
+     toEqual("<p>round</p>\n");
+    });
+
+    it("can override templates without registering them", function() {
+    	var christmasTree = {shape:"round"};
+    	expect(Jaml.render({
+    		shape: function(widget){
+      	  p(widget.shape)
+      	},
+    		div: function(widget){
+      	  div(render('shape', widget))
+      	}
+      }, "div", christmasTree )).
+     toEqual("<div><p>round</p>\n</div>\n");
+    });
+  });
 });
 

--- a/specs/template_spec.js
+++ b/specs/template_spec.js
@@ -1,10 +1,10 @@
 require("./spec_helper.js");
 
 describe("Jaml.Template", function() {
-  
+
   describe("all html tags", function() {
     it("a giant integration test for all html tags, so we see what we're allowing." +
-       "  intentionally locating this at the top of this spec file.", function(){      
+       "  intentionally locating this at the top of this spec file.", function(){
       expect(new Jaml.Template(function(){
                html(
                  head(
@@ -17,7 +17,7 @@ describe("Jaml.Template", function() {
                      thead(tr(th())),
                      tfoot(tr(td())),
                      tbody(tr(td()))
-                     
+
                    ),
                    ul(li(), ol()),
                    dl(), dt(), dd(),
@@ -32,7 +32,7 @@ describe("Jaml.Template", function() {
                    )
                  )
                )
-             }).render()).
+             })._render()).
      toEqual("<html>\n" +
              "  <head>\n" +
              "    <meta/>\n    <script></script>\n    <title/>\n    <link/>\n" +
@@ -62,7 +62,7 @@ describe("Jaml.Template", function() {
              "</html>\n");
     });
   });
-  
+
   describe("basic", function() {
     it("renders", function(){
       expect(new Jaml.Template(function(){
@@ -70,29 +70,29 @@ describe("Jaml.Template", function() {
                  li("red"),
                  li("green")
                )
-             }).render()).
+             })._render()).
      toEqual("<ul>\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n");
     });
-    
+
     it("renders with data", function(){
       var theWidget = {primaryColor: "red", secondaryColor: "green"}
-      
+
       expect(new Jaml.Template(function(widget){
                ul(
                  li(widget.primaryColor),
                  li(widget.secondaryColor)
                )
-             }).render(theWidget)).
+             })._render(theWidget)).
      toEqual("<ul>\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n");
-    });    
+    });
   });
-  
+
   describe("array data", function() {
     it("renders the template for each item in the array", function(){
       expect(new Jaml.Template(function(widget, i){
@@ -100,22 +100,22 @@ describe("Jaml.Template", function() {
                  li(widget.primaryColor),
                  li(widget.secondaryColor)
                )
-             }).render([
+             })._render([
                {primaryColor: "red", secondaryColor: "green"},
                {primaryColor: "orange", secondaryColor: "blue"},
                {primaryColor: "yellow", secondaryColor: "purple"}
              ])).
      toEqual("<ul id=\"0\">\n" +
              "  <li>red</li>\n" +
-             "  <li>green</li>\n" + 
+             "  <li>green</li>\n" +
              "</ul>\n" +
              "<ul id=\"1\">\n" +
              "  <li>orange</li>\n" +
-             "  <li>blue</li>\n" + 
+             "  <li>blue</li>\n" +
              "</ul>\n" +
              "<ul id=\"2\">\n" +
              "  <li>yellow</li>\n" +
-             "  <li>purple</li>\n" + 
+             "  <li>purple</li>\n" +
              "</ul>\n");
     });
     it("renders the template for each item in the array, using thisObj", function(){
@@ -124,26 +124,26 @@ describe("Jaml.Template", function() {
                    li(widget.primaryColor),
                    li(widget.secondaryColor)
                  )
-               }).render({data: "test"}, [
+               })._render({data: "test"}, [
                  {primaryColor: "red", secondaryColor: "green"},
                  {primaryColor: "orange", secondaryColor: "blue"},
                  {primaryColor: "yellow", secondaryColor: "purple"}
                ])).
        toEqual("<ul data=\"test\" id=\"0\">\n" +
                "  <li>red</li>\n" +
-               "  <li>green</li>\n" + 
+               "  <li>green</li>\n" +
                "</ul>\n" +
                "<ul data=\"test\" id=\"1\">\n" +
                "  <li>orange</li>\n" +
-               "  <li>blue</li>\n" + 
+               "  <li>blue</li>\n" +
                "</ul>\n" +
                "<ul data=\"test\" id=\"2\">\n" +
                "  <li>yellow</li>\n" +
-               "  <li>purple</li>\n" + 
+               "  <li>purple</li>\n" +
                "</ul>\n");
       });
   });
-  
-  
+
+
 });
 

--- a/src/Jaml.js
+++ b/src/Jaml.js
@@ -6,9 +6,18 @@
  * Introduction: http://edspencer.net/2009/11/jaml-beautiful-html-generation-for-javascript.html
  */
 Jaml = function() {
+	var merge = function() {
+		var obj = {};
+		for(var x=0;x<arguments.length;x++) {
+			for(var name in arguments[x])
+				obj[name] = arguments[x][name];
+		}
+		return obj;
+	}
+
   return {
     templates: {},
-        
+
     /**
      * Registers a template by name
      * @param {String} name The name of the template
@@ -17,17 +26,27 @@ Jaml = function() {
     register: function(name, template) {
       this.templates[name] = template;
     },
-    
+
     /**
      * Renders the given template name with an optional data object
      * @param {String} name The name of the template to render
      * @param {Object} thisObj Optional data object
      * @param {Object} data Optional data object
      */
-    render: function(name, thisObj, data) {
-      var template = this.templates[name],
-          renderer = new Jaml.Template(template);
-      return renderer.render.apply(renderer, Array.prototype.slice.call(arguments, 1));
+    render: function(templates, name, thisObj, data) {
+    	var tmpls, args;
+    	if(typeof templates === 'object') {
+    		tmpls = merge(this.templates, templates);
+    		args = Array.prototype.slice.call(arguments, 1);
+    	}
+    	else {
+    		args = arguments;
+    		tmpls = this.templates;
+    	}
+
+    	var template = typeof args[0] === 'function' ? args[0] : tmpls[args[0]],
+          renderer = new Jaml.Template(template, tmpls);
+      return renderer._render.apply(renderer, Array.prototype.slice.call(args, 1));
     }
   };
 }();


### PR DESCRIPTION
This allow to write:

Jaml.render(function(data) { div(....) }, data);
to easily use a template without registering it

Jaml.register('tmpl', function(data) {....});
Jaml.render({tmpl: function(data) { div(....) }}, 'tmpl', data);
to ovveride a template without overwriting already registered template

A slightly more complex example:
Jaml.register('tmpl', function(data) { p(....)});
Jaml.register('tmpl2', function(data) { div(render('tmpl', data))});
Jaml.render({
  tmpl: function(data) { div(....) }
}, 'tmpl2', data); -> &lt;div&gt;&lt;div&gt;....&lt;/div&gt;&lt;/div&gt;
Jaml.render('tmpl2', data); -> &lt;div&gt;&lt;p&gt;....&lt;/p&gt;&lt;/div&gt;

To allow "render" function in place of Jaml.render I had to rename "render" method in Jaml.Template to "_render".
I changed tests according to it and added two more.

This is just an idea, even if I'm using theese changes in a large project where I need to improve reusability of templates and avoid accidental overwrites.
